### PR TITLE
Reduce specificity of app.kubernetes.io/part-of label

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ SECURITY.md                - Security Policy and Reporting
 ```yaml
 dependencies:
 - name: patroni
-    version: 0.0.1
+    version: 0.0.2
     repository: https://bcgov.github.io/nr-patroni-chart
     # by default, the object created will be named <your-app>-patroni. You can use an alias to override the -patroni suffix
     alias: postgres

--- a/charts/patroni/Chart.yaml
+++ b/charts/patroni/Chart.yaml
@@ -3,7 +3,7 @@ name: patroni
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 kubeVersion: ">= 1.13.0"
 description: A Helm chart for a Patroni Postgresql database cluster
 # A chart can be either an 'application' or a 'library' chart.

--- a/charts/patroni/templates/_helpers.tpl
+++ b/charts/patroni/templates/_helpers.tpl
@@ -42,7 +42,7 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/component: database
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-app.kubernetes.io/part-of: {{ include "patroni.fullname" . }}
+app.kubernetes.io/part-of: {{ .Release.Name }}
 app.openshift.io/runtime: postgresql
 {{- end }}
 

--- a/charts/patroni/values.yaml
+++ b/charts/patroni/values.yaml
@@ -73,7 +73,7 @@ resources:
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   limits:
-    cpu: 1000m
+    cpu: 500m
     memory: 512Mi
   requests:
     cpu: 50m


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
We will not be able to meaningfully scope and inherit what this Patroni
instance is a part of, other than the common release name. As such, making
the value only have the release name as a pattern makes the most sense as
it will be the common thing binding this deployment along with anything
else that depends on it.
We also drop cpu limit to 500m for recommended defaults.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
